### PR TITLE
Fix LSP handling of URI-encoded paths

### DIFF
--- a/lib/rubocop/lsp/routes.rb
+++ b/lib/rubocop/lsp/routes.rb
@@ -194,7 +194,7 @@ module RuboCop
           return []
         end
 
-        new_text = @server.format(remove_file_protocol_from(file_uri), text, command: command)
+        new_text = @server.format(convert_file_uri_to_path(file_uri), text, command: command)
 
         return [] if new_text == text
 
@@ -214,13 +214,13 @@ module RuboCop
           method: 'textDocument/publishDiagnostics',
           params: {
             uri: file_uri,
-            diagnostics: @server.offenses(remove_file_protocol_from(file_uri), text)
+            diagnostics: @server.offenses(convert_file_uri_to_path(file_uri), text)
           }
         }
       end
 
-      def remove_file_protocol_from(uri)
-        uri.delete_prefix('file://')
+      def convert_file_uri_to_path(uri)
+        URI.decode_uri_component(uri.delete_prefix('file://'))
       end
     end
   end

--- a/spec/rubocop/lsp/server_spec.rb
+++ b/spec/rubocop/lsp/server_spec.rb
@@ -1381,4 +1381,33 @@ RSpec.describe RuboCop::LSP::Server, :isolated_environment do
       expect(messages.count).to eq(0)
     end
   end
+
+  describe 'when URI includes spaces' do
+    let(:requests) do
+      [
+        {
+          jsonrpc: '2.0',
+          method: 'textDocument/didOpen',
+          params: {
+            textDocument: {
+              languageId: 'ruby',
+              text: "puts 'hi'",
+              uri: 'file:///path/with%20spaces/file.rb',
+              version: 0
+            }
+          }
+        }
+      ]
+    end
+
+    it 'decodes URI-encoded paths for file system operations' do
+      # rubocop:disable RSpec/AnyInstance
+      expect_any_instance_of(RuboCop::Runner).to receive(:run).with(
+        ['/path/with spaces/file.rb']
+      ).and_call_original
+      # rubocop:enable RSpec/AnyInstance
+
+      result
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This fixes an issue where RuboCop's LSP server couldn't find config files when the project path contains spaces.

The LSP protocol sends file paths as URI-encoded strings (e.g., spaces become `%20`). Without decoding these, RuboCop would look for `.rubocop.yml` in non-existent directories like `/path/with%20spaces/` instead of `/path/with spaces/`.

## Test plan

- Added a test that verifies URI-encoded paths are properly decoded
- Tested with projects on external drives (which often have spaces in their names)
- All existing LSP tests continue to pass

Related issue: https://github.com/zed-extensions/ruby/issues/139

🤖 Generated with [Claude Code](https://claude.ai/code)